### PR TITLE
Add json-metrics-file flag and minor improvements including documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,29 @@ Summary:
  Req/s...........................: 6547.48
 ```
 
+Example exporting **cassowary** json metrics to a file:
+
+```sh
+$ ./cassowary run --json-metrics --json-metrics-file=metrics.json -u http://localhost:5000 -c 125 -n 100000
+
+Starting Load Test with 100000 requests using 125 concurrent users
+
+ 100% |████████████████████████████████████████| [0s:0s]            984.9862ms
+
+
+ TCP Connect.....................: Avg/mean=-0.18ms     Median=0.00ms   p(95)=1ms
+ Server Processing...............: Avg/mean=0.16ms      Median=0.00ms   p(95)=1ms
+ Content Transfer................: Avg/mean=0.01ms      Median=0.00ms   p(95)=0ms
+
+Summary:
+ Total Req.......................: 100000
+ Failed Req......................: 0
+ DNS Lookup......................: 2.00ms
+ Req/s...........................: 101524.27
+```
+
+> If `json-metrics-file` flag is missing then the default filename is `out.json`.
+
 Project Status & Contribute  
 --------
 

--- a/load.go
+++ b/load.go
@@ -260,7 +260,7 @@ func (c *cassowary) coordinate() error {
 	}
 
 	if c.exportMetrics {
-		c.outPutJSON(failedR, stringToFloat(reqS), tcpMean, tcpMedian, tcp95, serverMean, serverMedian, server95, transferMean, transferMedian, transfer95)
+		return c.outPutJSON(failedR, stringToFloat(reqS), tcpMean, tcpMedian, tcp95, serverMean, serverMedian, server95, transferMean, transferMedian, transfer95)
 	}
 
 	//fmt.Println(tcpDur)

--- a/summary.go
+++ b/summary.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 
 	"github.com/fatih/color"
@@ -54,7 +54,8 @@ func printf(format string, a ...interface{}) {
 	fmt.Fprintf(color.Output, format, a...)
 }
 
-func (c *cassowary) outPutJSON(failedReq int, requestPerSec, tcpMean, tcpMed float64, tcp9p string, serverMean, serverMed float64, server95p string, contentMean, contentMed float64, content95p string) {
+// TODO: replace all these args to a single structure.
+func (c *cassowary) outPutJSON(failedReq int, requestPerSec, tcpMean, tcpMed float64, tcp9p string, serverMean, serverMed float64, server95p string, contentMean, contentMed float64, content95p string) error {
 	tcp9P, _ := strconv.Atoi(tcp9p)
 	server95P, _ := strconv.Atoi(server95p)
 	content95P, _ := strconv.Atoi(content95p)
@@ -80,13 +81,16 @@ func (c *cassowary) outPutJSON(failedReq int, requestPerSec, tcpMean, tcpMed flo
 		},
 	}
 
-	b, err := json.Marshal(output)
-	if err != nil {
-		fmt.Println(err)
-		return
+	if c.exportMetricsFile == "" {
+		c.exportMetricsFile = "out.json" // default filename for json metrics output.
 	}
-	err = ioutil.WriteFile("out.json", b, 0644)
+
+	f, err := os.OpenFile(c.exportMetricsFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
-		fmt.Println(err)
+		return err
 	}
+	defer f.Close()
+
+	enc := json.NewEncoder(f)
+	return enc.Encode(output)
 }

--- a/summary.go
+++ b/summary.go
@@ -81,11 +81,13 @@ func (c *cassowary) outPutJSON(failedReq int, requestPerSec, tcpMean, tcpMed flo
 		},
 	}
 
-	if c.exportMetricsFile == "" {
-		c.exportMetricsFile = "out.json" // default filename for json metrics output.
+	filename := c.exportMetricsFile
+	if filename == "" {
+		// default filename for json metrics output.
+		filename = "out.json"
 	}
 
-	f, err := os.OpenFile(c.exportMetricsFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	f, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Hello @rogerwelin, it's me again.

I have pushed a small PR which adds a `--json-metrics-file=custom_filename.json` flag, sometimes you really need it. The default value, if `json-metrics` is true but the new flag is missing, it's the `out.json` as previously. The `json-metrics` flag stays as it's. I also added it to the README.md (the json output feature was missing from there). And last, the `c.outPutJSON` now returns an error instead of just `fmt.Println(err)` and the caller (CLI) returns it as well.