### PR TITLE
fix: support proxy setting from env vars

### DIFF
--- a/pkg/client/load.go
+++ b/pkg/client/load.go
@@ -102,7 +102,6 @@ func (c *Cassowary) runLoadTest(outPutChan chan<- durationMetrics, workerChan ch
 		}
 
 		request = request.WithContext(httptrace.WithClientTrace(context.Background(), trace))
-		c.Client.Transport.(*http.Transport).Proxy = http.ProxyFromEnvironment
 		resp, err := c.Client.Do(request)
 		if err != nil {
 			log.Fatalf("%v", err)
@@ -170,6 +169,7 @@ func (c *Cassowary) Coordinate() (ResultMetrics, error) {
 			MaxIdleConnsPerHost: 10000,
 			DisableCompression:  false,
 			DisableKeepAlives:   c.DisableKeepAlive,
+			Proxy:               http.ProxyFromEnvironment,
 		},
 	}
 

--- a/pkg/client/load.go
+++ b/pkg/client/load.go
@@ -102,6 +102,7 @@ func (c *Cassowary) runLoadTest(outPutChan chan<- durationMetrics, workerChan ch
 		}
 
 		request = request.WithContext(httptrace.WithClientTrace(context.Background(), trace))
+		c.Client.Transport.(*http.Transport).Proxy = http.ProxyFromEnvironment
 		resp, err := c.Client.Do(request)
 		if err != nil {
 			log.Fatalf("%v", err)


### PR DESCRIPTION
Fixes #54 

Support HTTP_PROXY, HTTPS_PROXY or NO_PROXY being set as environment variables.

e.g., `export HTTPS_PROXY=http://127.0.0.1:38080`