### PR TITLE
Client Certificate Renegotiation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,9 +306,9 @@ Starting Load Test with 1000 requests using 10 concurrent users
 Example specifying client authentication for mTLS
 
 ```bash
-$ ./cassowary run -u https://localhost:8443 -c 10 -n 1000 --cert /path/to/client.pem --key /path/to/client-key.pem --ca /path/to/ca.pem
+$ ./cassowary run -u https://localhost:8443 -c 10 -n 1000 --cert /path/to/client.pem --key /path/to/client-key.pem --ca /path/to/ca.pem --renegotiation once
 
-Starting Load Test with 1000 requests using 10 concurrent users
+Starting Load Test with 1000 requests using 10 concurrent users, allows the server to renegotiate client certificates once. This is needed for servers that optionally request client certificates.
 
 [ omitted for brevity ]
 

--- a/cmd/cassowary/cli.go
+++ b/cmd/cassowary/cli.go
@@ -176,26 +176,23 @@ func validateCLI(c *cli.Context) error {
 		httpMethod = "GET"
 	}
 
-    tlsConfig := new(tls.Config)
+	tlsConfig := new(tls.Config)
 	if c.Bool("insecure") {
 		tlsConfig.InsecureSkipVerify = true
-    }
+	}
 
-    if c.String("renegotiation") != "" {
-        switch option := c.String("renegotiation"); option {
-        case "never":
-            tlsConfig.Renegotiation = tls.RenegotiateNever
-        case "once":
-            tlsConfig.Renegotiation = tls.RenegotiateOnceAsClient
-        case "freely":
-            tlsConfig.Renegotiation = tls.RenegotiateFreelyAsClient
-        default:
-            return fmt.Errorf("invalid renegotiation option specified: %q", option)
-        }
-	} else {
-        tlsConfig.Renegotiation = tls.RenegotiateNever
-    }
-
+	if c.String("renegotiation") != "" {
+		switch option := c.String("renegotiation"); option {
+		case "never":
+			tlsConfig.Renegotiation = tls.RenegotiateNever
+		case "once":
+			tlsConfig.Renegotiation = tls.RenegotiateOnceAsClient
+		case "freely":
+			tlsConfig.Renegotiation = tls.RenegotiateFreelyAsClient
+		default:
+			return fmt.Errorf("invalid renegotiation option specified: %q", option)
+		}
+	}
 
 	if c.String("ca") != "" {
 		pemCerts, err := os.ReadFile(c.String("ca"))
@@ -355,11 +352,11 @@ func runCLI(args []string) {
 					Name:  "insecure",
 					Usage: "use this flag to skip ssl verification",
 				},
-                &cli.StringFlag{
-                    Name: "renegotiation",
-                    Usage: "Allow client certificate renegotiation: never, once, freely",
-                    Value: "never",
-                }, 
+				&cli.StringFlag{
+					Name:  "renegotiation",
+					Usage: "Allow client certificate renegotiation: never, once, freely",
+					Value: "never",
+				},
 				&cli.StringFlag{
 					Name:  "ca",
 					Usage: "ca certificate to verify peer against",

--- a/cmd/cassowary/cli.go
+++ b/cmd/cassowary/cli.go
@@ -176,10 +176,26 @@ func validateCLI(c *cli.Context) error {
 		httpMethod = "GET"
 	}
 
-	tlsConfig := new(tls.Config)
+    tlsConfig := new(tls.Config)
 	if c.Bool("insecure") {
 		tlsConfig.InsecureSkipVerify = true
-	}
+    }
+
+    if c.String("renegotiation") != "" {
+        switch option := c.String("renegotiation"); option {
+        case "never":
+            tlsConfig.Renegotiation = tls.RenegotiateNever
+        case "once":
+            tlsConfig.Renegotiation = tls.RenegotiateOnceAsClient
+        case "freely":
+            tlsConfig.Renegotiation = tls.RenegotiateFreelyAsClient
+        default:
+            return fmt.Errorf("invalid renegotiation option specified: %q", option)
+        }
+	} else {
+        tlsConfig.Renegotiation = tls.RenegotiateNever
+    }
+
 
 	if c.String("ca") != "" {
 		pemCerts, err := os.ReadFile(c.String("ca"))
@@ -339,6 +355,11 @@ func runCLI(args []string) {
 					Name:  "insecure",
 					Usage: "use this flag to skip ssl verification",
 				},
+                &cli.StringFlag{
+                    Name: "renegotiation",
+                    Usage: "Allow client certificate renegotiation: never, once, freely",
+                    Value: "never",
+                }, 
 				&cli.StringFlag{
 					Name:  "ca",
 					Usage: "ca certificate to verify peer against",


### PR DESCRIPTION
I added client certificate renegotiation support. I needed it because I was testing an API Gateway that optionally requests for a client certificate. It does this by using client certificate renegotiation. When the client has a certificate to offer it can do so at that point in time (but only when this option is enabled).

The option supports the three forms of renegotiations that the underlying TLS library supports: never, once, freely.

I hope my code is "go"-ish. I referenced example code for the layout. This is my first code in go so please be kind :-D

If you want me to change anything let me know. I can't edit the Chinese documentation and I didn't want to use google translate or AI to translate it because I can't check the results.